### PR TITLE
CON-306-Suppression fix, implement var-setters.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,11 +17,6 @@ variables:
     required: false
     type: string
     default: "NOT_A_TAG"
-  AUDIT_AWS_ELB_HTML_REPORT:
-    description: "Would you like to send the AWS owner tag report(s)? Options - notify / nothing. Default is nothing."
-    required: true
-    type: string
-    default: "nothing"  
   AUDIT_AWS_ELB_ROLLUP_REPORT:
     description: "Would you like to send a Summary ELB report? Options - notify / nothing. Default is nothing."
     required: true

--- a/config.yaml
+++ b/config.yaml
@@ -17,11 +17,6 @@ variables:
     required: false
     type: string
     default: "NOT_A_TAG"
-  AUDIT_AWS_ELB_ROLLUP_REPORT:
-    description: "Would you like to send a Summary ELB report? Options - notify / nothing. Default is nothing."
-    required: true
-    type: string
-    default: "nothing"
   AUDIT_AWS_ELB_ALLOW_EMPTY:
     description: "Would you like to receive empty reports? Options - true / false. Default is false."
     required: true

--- a/services/config.rb
+++ b/services/config.rb
@@ -93,7 +93,7 @@ function setTableAndSuppression() {
   } catch (e) {
   }
   coreoExport('table', JSON.stringify(table));
-  coreoExport('suppression', JSON.stringify(table));
+  coreoExport('suppression', JSON.stringify(suppression));
   
   let alertListToJSON = "${AUDIT_AWS_ELB_ALERT_LIST}";
   let alertListArray = alertListToJSON.replace(/'/g, '"');

--- a/services/config.rb
+++ b/services/config.rb
@@ -3,7 +3,7 @@ coreo_aws_rule "elb-inventory" do
   action :define
   service :elb
   link "http://kb.cloudcoreo.com/mydoc_elb-inventory.html"
-  include_violations_in_count false
+  include_violations_in_count true
   display_name "ELB Object Inventory"
   description "This rule performs an inventory on all Classic ELB's in the target AWS account."
   category "Inventory"
@@ -39,7 +39,7 @@ coreo_aws_rule "elb-current-ssl-policy" do
   action :define
   service :elb
   link "http://kb.cloudcoreo.com/mydoc_elb-current-ssl-policy.html"
-  include_violations_in_count false
+  include_violations_in_count true
   display_name "ELB is using current SSL policy"
   description "Elastic Load Balancing (ELB) SSL policy is the latest Amazon predefined SSL policy"
   category "Informational"
@@ -89,7 +89,7 @@ function setTableAndSuppression() {
   const yaml = require('js-yaml');
   try {
       table = yaml.safeLoad(fs.readFileSync('./table.yaml', 'utf8'));
-      suppression = yaml.safeLoad(fs.readFileSync('./table.yaml', 'utf8'));
+      suppression = yaml.safeLoad(fs.readFileSync('./suppression.yaml', 'utf8'));
   } catch (e) {
   }
   coreoExport('table', JSON.stringify(table));

--- a/services/config.rb
+++ b/services/config.rb
@@ -55,16 +55,37 @@ coreo_aws_rule "elb-current-ssl-policy" do
   id_map "modifiers.load_balancer_name"
 end
 
+coreo_uni_util_variables "planwide" do
+  action :set
+  variables([
+                {'COMPOSITE::coreo_uni_util_variables.planwide.composite_name' => 'PLAN::stack_name'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.plan_name' => 'PLAN::name'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.results' => 'unset'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.number_violations' => 'unset'}
+            ])
+end
+
+
 coreo_aws_rule_runner_elb "advise-elb" do
   rules ${AUDIT_AWS_ELB_ALERT_LIST}
   action :run
   regions ${AUDIT_AWS_ELB_REGIONS}
 end
 
+coreo_uni_util_variables "update-planwide-1" do
+  action :set
+  variables([
+                {'COMPOSITE::coreo_uni_util_variables.planwide.results' => 'COMPOSITE::coreo_aws_rule_runner_elb.advise-elb.report'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.number_violations' => 'COMPOSITE::coreo_aws_rule_runner_elb.advise-elb.number_violations'},
+
+            ])
+end
+
 
 coreo_uni_util_jsrunner "elb-tags-to-notifiers-array" do
   action :run
   data_type "json"
+  provide_composite_access true
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",

--- a/services/config.rb
+++ b/services/config.rb
@@ -175,12 +175,12 @@ callback(textRollup);
 end
 
 coreo_uni_util_notify "advise-elb-to-tag-values" do
-  action :${AUDIT_AWS_ELB_HTML_REPORT}
+  action((("${AUDIT_AWS_ELB_ALERT_RECIPIENT}".length > 0)) ? :notify : :nothing)
   notifiers 'COMPOSITE::coreo_uni_util_jsrunner.elb-tags-to-notifiers-array.return'
 end
 
 coreo_uni_util_notify "advise-elb-rollup" do
-  action :${AUDIT_AWS_ELB_ROLLUP_REPORT}
+  action((("${AUDIT_AWS_ELB_ALERT_RECIPIENT}".length > 0) and (! "${AUDIT_AWS_ELB_OWNER_TAG}".eql?("NOT_A_TAG"))) ? :notify : :nothing)
   type 'email'
   allow_empty ${AUDIT_AWS_ELB_ALLOW_EMPTY}
   send_on "${AUDIT_AWS_ELB_SEND_ON}"

--- a/services/config.rb
+++ b/services/config.rb
@@ -139,9 +139,24 @@ const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG,
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
 const AuditELB = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
 const notifiers = AuditELB.getNotifiers();
+
+const JSONReportAfterGeneratingSuppression = AuditELB.getJSONForAuditPanel();
+coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
+
 callback(notifiers);
   EOH
 end
+
+
+
+coreo_uni_util_variables "update-planwide-3" do
+  action :set
+  variables([
+                {'COMPOSITE::coreo_uni_util_variables.planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.elb-tags-to-notifiers-array.JSONReport'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.elb-tags-to-notifiers-array.table'}
+            ])
+end
+
 
 coreo_uni_util_jsrunner "elb-tags-rollup" do
   action :run

--- a/services/config.rb
+++ b/services/config.rb
@@ -69,6 +69,10 @@ coreo_uni_util_jsrunner "elb-tags-to-notifiers-array" do
                {
                    :name => "cloudcoreo-jsrunner-commons",
                    :version => "1.8.2"
+               },
+               {
+                   :name => "js-yaml",
+                   :version => "3.7.0"
                }       ])
   json_input '{ "composite name":"PLAN::stack_name",
                 "plan name":"PLAN::name",


### PR DESCRIPTION
CON-290 Cloudtrail jsrunner error if suppression.yaml file does not exist.
CON-303 must provide_composite_access to get to table and suppression yaml.
CON-304 remove action vars for audit notifiers.
CON-293 implement the var-setters and planwide changes across all audit stacks.
CON-294 decrement violation counts in the suppressions across audit stacks.