### PR TITLE
CON-390 Update all audit stack new version cloudcoreojsrunner.

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -87,7 +87,7 @@ coreo_uni_util_jsrunner "elb-tags-to-notifiers-array" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.8.3"
+                   :version => "*"
                },
                {
                    :name => "js-yaml",
@@ -95,6 +95,7 @@ coreo_uni_util_jsrunner "elb-tags-to-notifiers-array" do
                }       ])
   json_input '{ "composite name":"PLAN::stack_name",
                 "plan name":"PLAN::name",
+                "cloud account name": "PLAN::cloud_account_name",
                 "violations": COMPOSITE::coreo_aws_rule_runner_elb.advise-elb.report}'
   function <<-EOH
   
@@ -143,19 +144,20 @@ const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG,
 
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
 const AuditELB = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
-const notifiers = AuditELB.getNotifiers();
+const letters = AuditELB.getLetters();
 
-const JSONReportAfterGeneratingSuppression = AuditELB.getJSONForAuditPanel();
-coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
+const newJSONInput = AuditELB.getSortedJSONForAuditPanel();
+coreoExport('JSONReport', JSON.stringify(newJSONInput));
+coreoExport('report', JSON.stringify(newJSONInput['violations']));
 
-callback(notifiers);
+callback(letters);
   EOH
 end
 
 coreo_uni_util_variables "elb-update-planwide-3" do
   action :set
   variables([
-                {'COMPOSITE::coreo_uni_util_variables.elb-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.elb-tags-to-notifiers-array.JSONReport'},
+                {'COMPOSITE::coreo_uni_util_variables.elb-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.elb-tags-to-notifiers-array.JSONReport'},{'COMPOSITE::coreo_aws_rule_runner_elb.advise-elb.report' => 'COMPOSITE::coreo_uni_util_jsrunner.elb-tags-to-notifiers-array.report'},
                 {'COMPOSITE::coreo_uni_util_variables.elb-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.elb-tags-to-notifiers-array.table'}
             ])
 end


### PR DESCRIPTION
PLA-3163 Engine does not support empty rules array
CON-287 Audit reports in WebUI and email don't list which AWS account being run on
CON-318 display meta_ attributes on cards
CON-334 add notifiers and jsrunner structures to the AWS config composite
CON-376 Report Emails: Update '# Resources' on cards to '# Cloud Objects'